### PR TITLE
Add an action that checks the syntax of the template file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,37 @@
+# Check the syntax of the dictionary template files
+
+name: CIF Syntax Check
+
+# Controls when the action will run. Triggers the workflow on push or pull
+# request events but only for the main branch
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  syntax:
+    name: Syntax
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Check syntax of all CIF files
+      - name: Check CIF syntax
+        uses: COMCIFS/cif_syntax_check_action@master
+        id: cif_syntax_check


### PR DESCRIPTION
The action currently only checks the CIF file syntax since the Semantics and Style check have not yet been adapted for template files.