### PR TITLE
Switch to enumeration_defaults system.

### DIFF
--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -11,8 +11,8 @@ data_TEMPL_ATTR
     _dictionary.title            TEMPL_ATTR
     _dictionary.class            Template
     _dictionary.version          1.4.11
-    _dictionary.date             2025-05-19
-    _dictionary.uri              https://raw.githubusercontent.com/COMCIFS/cif_core/master/templ_attr.cif
+    _dictionary.date             2026-04-09
+    _dictionary.uri              https://raw.githubusercontent.com/COMCIFS/Attribute_Templates/main/templ_attr.cif
     _dictionary.ddl_conformance  4.2.0
     _description.text
 ;
@@ -784,7 +784,7 @@ save_
 
 save_cromer_mann_coeff
 
-    _definition.update           2023-06-03
+    _definition.update           2026-04-09
     _description.text
 ;
     The set of data items used to define Cromer-Mann coefficients
@@ -804,13 +804,13 @@ save_cromer_mann_coeff
     _type.source                 Assigned
     _type.container              Single
     _type.contents               Real
-    _enumeration.def_index_id  '_atom_type.symbol'
+    _enumeration.def_index_ids   ['_atom_type.symbol']
      save_
 
 
 save_hi_ang_fox_coeffs
 
-    _definition.update           2023-06-03
+    _definition.update           2026-04-09
     _description.text
 ;
     The set of data items used to define Fox et al. coefficients
@@ -828,7 +828,7 @@ save_hi_ang_fox_coeffs
     _type.source                 Assigned
     _type.container              Single
     _type.contents               Real
-    _enumeration.def_index_id  '_atom_type.symbol'
+    _enumeration.def_index_ids   ['_atom_type.symbol']
      save_
 
 
@@ -1127,7 +1127,7 @@ save_display_colour
 
        Updated description of _site_symmetry.
 ;
-         1.4.11                   2025-05-19
+         1.4.11                   2026-04-09
 ;
        # Please update the date above and describe the change below until
        # ready for the next release
@@ -1161,4 +1161,6 @@ save_display_colour
        Updated description of _site_symmetry.
 
        Added reference to cartn_matrix and fract_matrix.
+
+       Use _enumeration.def_index_ids
 ;

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -769,7 +769,7 @@ save_
 
 save_cromer_mann_coeff
 
-    _definition.update           2026-04-09
+    _definition.update           2026-04-20
     _description.text
 ;
     The set of data items used to define Cromer-Mann coefficients
@@ -795,7 +795,7 @@ save_cromer_mann_coeff
 
 save_hi_ang_fox_coeffs
 
-    _definition.update           2026-04-09
+    _definition.update           2026-04-20
     _description.text
 ;
     The set of data items used to define Fox et al. coefficients


### PR DESCRIPTION
Use of enumeration_defaults requires enumeration.def_index_ids as the index list.

Also changed URL for this dictionary.