### PR TITLE
Corrected the definition of a* in _atom_site.B_iso_or_equiv and similar

### DIFF
--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -11,7 +11,7 @@ data_TEMPL_ATTR
     _dictionary.title            TEMPL_ATTR
     _dictionary.class            Template
     _dictionary.version          1.4.11
-    _dictionary.date             2025-05-19
+    _dictionary.date             2025-09-21
     _dictionary.uri              https://raw.githubusercontent.com/COMCIFS/cif_core/master/templ_attr.cif
     _dictionary.ddl_conformance  4.2.0
     _description.text
@@ -638,7 +638,7 @@ save_aniso_bij
          T = exp{-1/4 sum~i~ [ sum~j~ (B^ij^ h~i~ h~j~ a*~i~ a*~j~) ] }
 
      h = the Miller indices
-     a* = the reciprocal-space cell lengths
+     a* = the reciprocals of the direct-space cell lengths
 
      The unique elements of the real symmetric matrix are entered by row.
 
@@ -736,7 +736,7 @@ save_aniso_uij
         T = exp{ -2π^2^ sum~i~ [ sum~j~ (U^ij^ h~i~ h~j~ a*~i~ a*~j~) ] }
 
      h = the Miller indices
-     a* = the reciprocal-space cell lengths
+     a* = the reciprocals of the direct-space cell lengths
 
      The unique elements of the real symmetric matrix are entered by row.
 
@@ -1127,7 +1127,7 @@ save_display_colour
 
        Updated description of _site_symmetry.
 ;
-         1.4.11                   2025-05-19
+         1.4.11                   2025-09-21
 ;
        # Please update the date above and describe the change below until
        # ready for the next release
@@ -1161,4 +1161,7 @@ save_display_colour
        Updated description of _site_symmetry.
 
        Added reference to cartn_matrix and fract_matrix.
+
+       Corrected the definition of a* in save_aniso_bij and save_aniso_uij.
+       [bm, after Nespolo, M. (2024). J. Appl. Cryst. 57, 1733-1746]
 ;


### PR DESCRIPTION
These are the changes to `templ_attr.cif` introduced in https://github.com/COMCIFS/cif_core/pull/557.