### PR TITLE
Fix save frame cross reference

### DIFF
--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -180,6 +180,9 @@ save_matrix_w
     _description.text
 ;
      Element of the matrix W defined by van Smaalen (1991); (1995)
+
+     Smaalen, S. van (1991) Phys. Rev. B, 43, 11330-11341.
+     Smaalen, S. van (1995) Crystallogr. Rev. 4, 79-202.
 ;
     _type.purpose                Number
     _type.source                 Assigned

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -736,9 +736,10 @@ save_aniso_betaij_su
 ;
      These are the standard uncertainty values (s.u.) for the standard
      form of the β^ij^ anisotropic atomic displacement components (see
-     aniso_betaIJ). Because these values are _type.purpose Measurand, the
-     s.u. values may in practice be auto generated as part of the
-     β^ij^ calculation.
+     the linked data name for further details).
+
+     Because these values are _type.purpose Measurand, the s.u. values
+     may in practice be auto generated as part of the β^ij^ calculation.
 ;
     _type.purpose                SU
     _type.source                 Related

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -687,9 +687,10 @@ save_aniso_bij_su
 ;
      These are the standard uncertainty values (s.u.) for the standard
      form of the B^ij^ anisotropic atomic displacement components (see
-     aniso_BIJ). Because these values are _type.purpose Measurand, the
-     s.u. values may in practice be auto generated as part of the
-     B^ij^ calculation.
+     the linked data name for further details).
+
+     Because these values are _type.purpose Measurand, the s.u. values
+     may in practice be auto generated as part of the B^ij^ calculation.
 ;
     _type.purpose                SU
     _type.source                 Related

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -786,9 +786,10 @@ save_aniso_uij_su
 ;
      These are the standard uncertainty values (s.u.) for the standard
      form of the U^ij^ anisotropic atomic displacement components (see
-     aniso_UIJ). Because these values are _type.purpose Measurand, the
-     s.u. values may in practice be auto generated as part of the
-     U^ij^ calculation.
+     the linked data name for further details).
+
+     Because these values are _type.purpose Measurand, the s.u. values
+     may in practice be auto generated as part of the U^ij^ calculation.
 ;
     _type.purpose                SU
     _type.source                 Related

--- a/templ_attr.cif
+++ b/templ_attr.cif
@@ -688,12 +688,8 @@ save_aniso_bij_su
     _definition.update           2025-03-27
     _description.text
 ;
-     These are the standard uncertainty values (s.u.) for the standard
-     form of the B^ij^ anisotropic atomic displacement components (see
-     the linked data name for further details).
-
-     Because these values are _type.purpose Measurand, the s.u. values
-     may in practice be auto generated as part of the B^ij^ calculation.
+     Standard uncertainty of the indicated B^ij^ anisotropic atomic
+     displacement component.
 ;
     _type.purpose                SU
     _type.source                 Related
@@ -737,12 +733,8 @@ save_aniso_betaij_su
     _definition.update           2025-03-27
     _description.text
 ;
-     These are the standard uncertainty values (s.u.) for the standard
-     form of the β^ij^ anisotropic atomic displacement components (see
-     the linked data name for further details).
-
-     Because these values are _type.purpose Measurand, the s.u. values
-     may in practice be auto generated as part of the β^ij^ calculation.
+     Standard uncertainty of the indicated β^ij^ anisotropic atomic
+     displacement component.
 ;
     _type.purpose                SU
     _type.source                 Related
@@ -787,12 +779,8 @@ save_aniso_uij_su
     _definition.update           2025-03-27
     _description.text
 ;
-     These are the standard uncertainty values (s.u.) for the standard
-     form of the U^ij^ anisotropic atomic displacement components (see
-     the linked data name for further details).
-
-     Because these values are _type.purpose Measurand, the s.u. values
-     may in practice be auto generated as part of the U^ij^ calculation.
+     Standard uncertainty of the indicated U^ij^ anisotropic atomic
+     displacement component.
 ;
     _type.purpose                SU
     _type.source                 Related


### PR DESCRIPTION
will close #1 

cross referencing names in save frames removed.